### PR TITLE
Implement CorLibTypes.AssemblyRef, GetTypeRef, and TypeRef resolution

### DIFF
--- a/src/ManagedDotnetProfiler/CorProfiler.cs
+++ b/src/ManagedDotnetProfiler/CorProfiler.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;
+using dnlib.DotNet.MD;
+using dnlib.DotNet.Writer;
 using Silhouette.IL;
 
 namespace ManagedDotnetProfiler;
@@ -144,6 +146,7 @@ internal unsafe class CorProfiler : CorProfilerCallback10Base
                 Log($"ProfilerAttachComplete - Rewriting PInvoke maps for module {moduleInfo.ModuleName}");
                 RewritePInvokeMaps(moduleId);
                 RewriteSignatureTest(moduleId);
+                RewriteCorLibTypesProbe(moduleId);
                 break;
             }
         }
@@ -450,6 +453,7 @@ internal unsafe class CorProfiler : CorProfilerCallback10Base
         {
             RewritePInvokeMaps(moduleId);
             RewriteSignatureTest(moduleId);
+            RewriteCorLibTypesProbe(moduleId);
         }
 
         return HResult.S_OK;
@@ -482,6 +486,52 @@ internal unsafe class CorProfiler : CorProfilerCallback10Base
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldc_I8, ptr));
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Conv_I));
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Calli, sig));
+        method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+
+        ilRewriter.Export(method);
+    }
+
+    private void RewriteCorLibTypesProbe(ModuleId moduleId)
+    {
+        using var metaDataImport = ICorProfilerInfo2.GetModuleMetaDataImport2(moduleId, CorOpenFlags.ofRead | CorOpenFlags.ofWrite)
+            .ThrowIfFailed()
+            .Wrap();
+
+        var typeDef = metaDataImport.Value.FindTypeDefByName("TestApp.CorLibTypesTest", default).ThrowIfFailed();
+        var methodDef = metaDataImport.Value.FindMethod(typeDef, "CorLibTypesProbe", default).ThrowIfFailed();
+
+        var ilRewriter = IlRewriter.Create(ICorProfilerInfo3);
+        using var method = ilRewriter.Import(moduleId, methodDef);
+
+        var corLib = method.Metadata.CorLibTypes;
+
+        // Build MemberRefs using CorLibTypes TypeDefOrRef tokens as parents.
+        // If AssemblyRef/ResolveTypeSig are broken, TypeDefOrRef is a TypeDef(0) instead of
+        // a proper TypeRef, which produces MemberRefs pointing at <Module> → MissingMethodException.
+        using var metaDataEmit = ICorProfilerInfo2.GetModuleMetaDataEmit(moduleId, CorOpenFlags.ofRead | CorOpenFlags.ofWrite)
+            .ThrowIfFailed()
+            .Wrap();
+
+        var objectToken = new MdToken((int)corLib.Object.TypeDefOrRef.MDToken.Raw);
+        var stringToken = new MdToken((int)corLib.String.TypeDefOrRef.MDToken.Raw);
+
+        // Object.ToString(): instance string ()
+        var toStringSig = MethodSig.CreateInstance(corLib.String);
+        var toStringRef = metaDataEmit.Value.DefineMemberRef(
+            objectToken, "ToString", SignatureWriter.Write(method.Metadata, toStringSig)).ThrowIfFailed();
+        var toStringOp = new MemberRefUser(null, "ToString", toStringSig) { Rid = MDToken.ToRID((uint)toStringRef.Value) };
+
+        // String.get_Length(): instance int32 ()
+        var getLengthSig = MethodSig.CreateInstance(corLib.Int32);
+        var getLengthRef = metaDataEmit.Value.DefineMemberRef(
+            stringToken, "get_Length", SignatureWriter.Write(method.Metadata, getLengthSig)).ThrowIfFailed();
+        var getLengthOp = new MemberRefUser(null, "get_Length", getLengthSig) { Rid = MDToken.ToRID((uint)getLengthRef.Value) };
+
+        // Rewrite method to: return "test".ToString().Length;  (== 4)
+        method.Body.Instructions.Clear();
+        method.Body.Instructions.Add(Instruction.Create(OpCodes.Ldstr, "test"));
+        method.Body.Instructions.Add(Instruction.Create(OpCodes.Callvirt, (IMethod)toStringOp));
+        method.Body.Instructions.Add(Instruction.Create(OpCodes.Callvirt, (IMethod)getLengthOp));
         method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
 
         ilRewriter.Export(method);

--- a/src/Silhouette.IL/CorLibTypes.cs
+++ b/src/Silhouette.IL/CorLibTypes.cs
@@ -2,14 +2,14 @@
 
 namespace Silhouette.IL;
 
-public class CorLibTypes : ICorLibTypes, IDisposable
+internal class CorLibTypes : ICorLibTypes, IDisposable
 {
     private readonly ComPtr<IMetaDataImport2> _metadataImport;
     private readonly ComPtr<IMetaDataImport2> _corLibMetadataImport;
     private readonly ModuleId _moduleId;
     private readonly ICorProfilerInfo3 _corProfilerInfo;
 
-    public static HResult<CorLibTypes> Create(ComPtr<IMetaDataImport2> metadataImport, ICorProfilerInfo3 corProfilerInfo, ModuleId moduleId = default)
+    internal static HResult<CorLibTypes> Create(ComPtr<IMetaDataImport2> metadataImport, ICorProfilerInfo3 corProfilerInfo, ModuleId moduleId)
     {
         var (result, corLib) = FindCorLib(corProfilerInfo);
 

--- a/src/Silhouette.IL/CorLibTypes.cs
+++ b/src/Silhouette.IL/CorLibTypes.cs
@@ -6,8 +6,10 @@ public class CorLibTypes : ICorLibTypes, IDisposable
 {
     private readonly ComPtr<IMetaDataImport2> _metadataImport;
     private readonly ComPtr<IMetaDataImport2> _corLibMetadataImport;
+    private readonly ModuleId _moduleId;
+    private readonly ICorProfilerInfo3 _corProfilerInfo;
 
-    public static HResult<CorLibTypes> Create(ComPtr<IMetaDataImport2> metadataImport, ICorProfilerInfo3 corProfilerInfo)
+    public static HResult<CorLibTypes> Create(ComPtr<IMetaDataImport2> metadataImport, ICorProfilerInfo3 corProfilerInfo, ModuleId moduleId = default)
     {
         var (result, corLib) = FindCorLib(corProfilerInfo);
 
@@ -18,13 +20,15 @@ public class CorLibTypes : ICorLibTypes, IDisposable
 
         using var corLibPtr = corLib.Wrap();
 
-        return new CorLibTypes(metadataImport, corLibPtr);
+        return new CorLibTypes(metadataImport, corLibPtr, moduleId, corProfilerInfo);
     }
 
-    private CorLibTypes(ComPtr<IMetaDataImport2> metadataImport, ComPtr<IMetaDataImport2> corLibMetadataImport)
+    private CorLibTypes(ComPtr<IMetaDataImport2> metadataImport, ComPtr<IMetaDataImport2> corLibMetadataImport, ModuleId moduleId, ICorProfilerInfo3 corProfilerInfo)
     {
         _metadataImport = metadataImport.Copy();
         _corLibMetadataImport = corLibMetadataImport.Copy();
+        _moduleId = moduleId;
+        _corProfilerInfo = corProfilerInfo;
     }
 
     private static HResult<IMetaDataImport2> FindCorLib(ICorProfilerInfo3 corProfilerInfo)
@@ -69,8 +73,30 @@ public class CorLibTypes : ICorLibTypes, IDisposable
 
     public TypeRef GetTypeRef(string @namespace, string name)
     {
-        Console.WriteLine($"GetTypeRef({@namespace}, {name})");
-        throw new NotImplementedException();
+        var fullName = string.IsNullOrEmpty(@namespace) ? name : $"{@namespace}.{name}";
+
+        // Try to find an existing TypeRef first
+        var existing = FindTypeRef(fullName);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        // Create a new one via IMetaDataEmit
+        var asmRef = AssemblyRef;
+        if (asmRef == null)
+        {
+            return null;
+        }
+
+        using var metaDataEmit = _corProfilerInfo.GetModuleMetaDataEmit(_moduleId, CorOpenFlags.ofRead | CorOpenFlags.ofWrite)
+            .ThrowIfFailed()
+            .Wrap();
+
+        var typeRef = metaDataEmit.Value.DefineTypeRefByName(
+            new MdToken((int)asmRef.MDToken.Raw), fullName).ThrowIfFailed();
+
+        return new TypeRefUser(null, @namespace, name) { Rid = MDToken.ToRID((uint)typeRef.Value) };
     }
 
     public CorLibTypeSig Void => new(new TypeDefUser("void"), ElementType.Void);
@@ -91,13 +117,63 @@ public class CorLibTypes : ICorLibTypes, IDisposable
     public CorLibTypeSig IntPtr => ResolveTypeSig("System.IntPtr", ElementType.I);
     public CorLibTypeSig UIntPtr => ResolveTypeSig("System.UIntPtr", ElementType.U);
     public CorLibTypeSig Object => ResolveTypeSig("System.Object", ElementType.Object);
-    public AssemblyRef AssemblyRef
+    public AssemblyRef AssemblyRef => _assemblyRef ??= FindCorLibAssemblyRef();
+
+    private AssemblyRef _assemblyRef;
+
+    // TODO: Replace enumeration with IMetaDataAssemblyImport.FindAssemblyRef or similar direct lookup
+    private AssemblyRef FindCorLibAssemblyRef()
     {
-        get
+        HCORENUM hEnum = default;
+        Span<MdTypeRef> typeRefs = stackalloc MdTypeRef[50];
+
+        try
         {
-            Console.WriteLine("AssemblyRef requested, returning null.");
+            while (_metadataImport.Value.EnumTypeRefs(ref hEnum, typeRefs, out var count) && count > 0)
+            {
+                for (int i = 0; i < (int)count; i++)
+                {
+                    var (hr, props) = _metadataImport.Value.GetTypeRefProps(typeRefs[i]);
+
+                    if (hr && props.TypeName == "System.Object")
+                    {
+                        return new AssemblyRefUser("corlib") { Rid = MDToken.ToRID((uint)props.ResolutionScope.Value) };
+                    }
+                }
+            }
+        }
+        finally
+        {
+            _metadataImport.Value.CloseEnum(hEnum);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the TypeRef token for a corlib type in the target module.
+    /// Returns null if the type is not referenced by the target module.
+    /// </summary>
+    private TypeRef FindTypeRef(string fullName)
+    {
+        var asmRef = AssemblyRef;
+
+        if (asmRef == null)
+        {
             return null;
         }
+
+        var (hr, typeRef) = _metadataImport.Value.FindTypeRef(new MdToken((int)asmRef.MDToken.Raw), fullName);
+
+        if (!hr)
+        {
+            return null;
+        }
+
+        var dot = fullName.LastIndexOf('.');
+        var ns = dot >= 0 ? fullName[..dot] : "";
+        var typeName = dot >= 0 ? fullName[(dot + 1)..] : fullName;
+        return new TypeRefUser(null, ns, typeName) { Rid = MDToken.ToRID((uint)typeRef.Value) };
     }
 
     private CorLibTypeSig ResolveTypeSig(string name, ElementType elementType)
@@ -108,6 +184,13 @@ public class CorLibTypes : ICorLibTypes, IDisposable
             Console.WriteLine($"Failed to find type definition for {name}: {result}");
             return default;
         }
+
+        var typeRef = FindTypeRef(name);
+        if (typeRef != null)
+        {
+            return new(typeRef, elementType);
+        }
+
         return new(new TypeDefUser(name), elementType);
     }
 

--- a/src/Silhouette.IL/InstructionOperandResolver.cs
+++ b/src/Silhouette.IL/InstructionOperandResolver.cs
@@ -25,7 +25,7 @@ public sealed class InstructionOperandResolver : IInstructionOperandResolver, ID
     {
         get
         {
-            _corLibTypes ??= CorLibTypes.Create(MetaDataImport, _corProfilerInfo).ThrowIfFailed();
+            _corLibTypes ??= CorLibTypes.Create(MetaDataImport, _corProfilerInfo, _moduleId).ThrowIfFailed();
             return _corLibTypes;
         }
     }

--- a/src/Silhouette.IL/InstructionOperandResolver.cs
+++ b/src/Silhouette.IL/InstructionOperandResolver.cs
@@ -21,11 +21,11 @@ public sealed class InstructionOperandResolver : IInstructionOperandResolver, ID
         _corProfilerInfo = corProfilerInfo;
     }
 
-    public CorLibTypes CorLibTypes
+    public ICorLibTypes CorLibTypes
     {
         get
         {
-            _corLibTypes ??= CorLibTypes.Create(MetaDataImport, _corProfilerInfo, _moduleId).ThrowIfFailed();
+            _corLibTypes ??= IL.CorLibTypes.Create(MetaDataImport, _corProfilerInfo, _moduleId).ThrowIfFailed();
             return _corLibTypes;
         }
     }

--- a/src/TestApp/CorLibTypesTest.cs
+++ b/src/TestApp/CorLibTypesTest.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+
+namespace TestApp;
+
+internal class CorLibTypesTest : ITest
+{
+    public void Run()
+    {
+        Logs.Clear();
+
+        // This method is rewritten by the profiler to call Object.ToString() on a string,
+        // using a MemberRef built from corLib.Object.TypeDefOrRef.MDToken as parent.
+        // If CorLibTypes.AssemblyRef/ResolveTypeSig are broken, the TypeDefOrRef is a
+        // TypeDef(0) instead of a proper TypeRef, producing a MemberRef for "<Module>.ToString()"
+        // which throws MissingMethodException at runtime.
+        var result = CorLibTypesProbe();
+        Logs.Assert(result == 4, $"CorLibTypesProbe returned {result} instead of 4");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int CorLibTypesProbe()
+    {
+        // Will be rewritten by the profiler to:
+        //   return "test".ToString().Length;  (== 4)
+        // using MemberRefs derived from CorLibTypes
+        return 0;
+    }
+}

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -30,6 +30,7 @@ if (args.Length >= 2 && args[0] == "--attach")
     attachTests.Add(new ModuleTests());
     attachTests.Add(new GenericArgumentsTests());
     attachTests.Add(new IlRewriteTest());
+    attachTests.Add(new CorLibTypesTest());
     attachTests.Add(new FunctionInfoTests());
 
     return RunTests(attachTests);
@@ -72,6 +73,7 @@ var tests = new List<ITest>
     new ModuleTests(),
     new GenericArgumentsTests(),
     new IlRewriteTest(),
+    new CorLibTypesTest(),
     new FunctionInfoTests()
 };
 


### PR DESCRIPTION
- **AssemblyRef**: Implemented by enumerating TypeRefs for `System.Object` and extracting its resolution scope (cached on first access)
- **GetTypeRef**: Finds existing TypeRef via `FindTypeRef`, falls back to `DefineTypeRefByName` if not present in the target module
- **ResolveTypeSig**: Now returns a `TypeRef` (not `TypeDef`) for corlib types when the target module references them, making `TypeDefOrRef` usable as a MemberRef parent token
- **CorLibTypesTest**: End-to-end test that rewrites a method using MemberRefs built from `CorLibTypes` tokens — fails with `MissingMethodException` (`<Module>.ToString()`) before these changes
