### PR TITLE
Add IMetaDataAssemblyImport and use it in CorLibTypes

### DIFF
--- a/src/ManagedDotnetProfiler/CorProfiler.cs
+++ b/src/ManagedDotnetProfiler/CorProfiler.cs
@@ -1426,4 +1426,139 @@ internal unsafe class CorProfiler : CorProfilerCallback10Base
         Log($"GetNativeCodeStartAddresses - Success");
         return true;
     }
+
+    internal unsafe int GetAssemblyImportData(char* buffer, int bufferLength)
+    {
+        // Find the TestApp module
+        var (enumResult, modules) = ICorProfilerInfo3.EnumModules();
+
+        if (!enumResult)
+        {
+            Error(enumResult, nameof(ICorProfilerInfo3.EnumModules));
+            return -1;
+        }
+
+        using var _ = modules;
+
+        ModuleId testAppModule = default;
+
+        foreach (var module in modules.AsEnumerable())
+        {
+            var (hr, moduleInfo) = ICorProfilerInfo.GetModuleInfo(module);
+
+            if (hr && Path.GetFileNameWithoutExtension(moduleInfo.ModuleName) == "TestApp")
+            {
+                testAppModule = module;
+                break;
+            }
+        }
+
+        if (testAppModule == default)
+        {
+            Error("TestApp module not found");
+            return -1;
+        }
+
+        using var assemblyImport = ICorProfilerInfo.GetModuleMetaDataAssemblyImport(testAppModule, CorOpenFlags.ofRead)
+            .ThrowIfFailed()
+            .Wrap();
+
+        // --- GetAssemblyFromScope ---
+        var (asmResult, asmToken) = assemblyImport.Value.GetAssemblyFromScope();
+
+        if (!asmResult)
+        {
+            Error(asmResult, "GetAssemblyFromScope");
+            return -1;
+        }
+
+        Log($"AssemblyImport - GetAssemblyFromScope token=0x{asmToken.Value:X8}");
+
+        // --- GetAssemblyProps ---
+        var (propsResult, asmProps) = assemblyImport.Value.GetAssemblyProps(asmToken);
+
+        if (!propsResult)
+        {
+            Error(propsResult, "GetAssemblyProps");
+            return -1;
+        }
+
+        Log($"AssemblyImport - GetAssemblyProps name={asmProps.Name} version={asmProps.Version.Major}.{asmProps.Version.Minor}.{asmProps.Version.Build}.{asmProps.Version.Revision} flags={asmProps.AssemblyFlags}");
+
+        // --- EnumAssemblyRefs + GetAssemblyRefProps ---
+        HCORENUM hEnum = default;
+        Span<MdAssemblyRef> assemblyRefs = stackalloc MdAssemblyRef[50];
+        var refEntries = new List<string>();
+
+        try
+        {
+            while (assemblyImport.Value.EnumAssemblyRefs(ref hEnum, assemblyRefs, out var count) && count > 0)
+            {
+                for (int i = 0; i < (int)count; i++)
+                {
+                    var (refResult, refProps) = assemblyImport.Value.GetAssemblyRefProps(assemblyRefs[i]);
+
+                    if (!refResult)
+                    {
+                        Error(refResult, $"GetAssemblyRefProps(0x{assemblyRefs[i].Value:X8})");
+                        return -1;
+                    }
+
+                    // Format: Name|Major.Minor.Build.Revision
+                    refEntries.Add($"{refProps.Name}|{refProps.Version.Major}.{refProps.Version.Minor}.{refProps.Version.Build}.{refProps.Version.Revision}");
+                }
+            }
+        }
+        finally
+        {
+            assemblyImport.Value.CloseEnum(hEnum);
+        }
+
+        refEntries.Sort(StringComparer.Ordinal);
+
+        foreach (var entry in refEntries)
+        {
+            Log($"AssemblyImport - AssemblyRef {entry}");
+        }
+
+        // --- EnumManifestResources ---
+        hEnum = default;
+        Span<MdManifestResource> resources = stackalloc MdManifestResource[50];
+        int resourceCount = 0;
+
+        try
+        {
+            while (assemblyImport.Value.EnumManifestResources(ref hEnum, resources, out var count) && count > 0)
+            {
+                resourceCount += (int)count;
+            }
+        }
+        finally
+        {
+            assemblyImport.Value.CloseEnum(hEnum);
+        }
+
+        Log($"AssemblyImport - ManifestResources count={resourceCount}");
+
+        // --- Write assembly ref entries to buffer for cross-checking ---
+        // Format: sorted "Name|Major.Minor.Build.Revision" null-terminated strings
+        int size = 0;
+
+        foreach (var entry in refEntries)
+        {
+            if (size + entry.Length + 1 > bufferLength)
+            {
+                Error("AssemblyImport buffer too small");
+                return -1;
+            }
+
+            entry.AsSpan().CopyTo(new Span<char>(buffer + size, entry.Length));
+            buffer[size + entry.Length] = '\0';
+
+            size += entry.Length + 1;
+        }
+
+        Log($"AssemblyImport - Success");
+        return size;
+    }
 }

--- a/src/ManagedDotnetProfiler/PInvoke.cs
+++ b/src/ManagedDotnetProfiler/PInvoke.cs
@@ -88,4 +88,10 @@ internal static unsafe class PInvoke
     {
         return Task.Run(() => CorProfiler.Instance.TestGetNativeCodeStartAddresses()).Result;
     }
+
+    [UnmanagedCallersOnly(EntryPoint = nameof(GetAssemblyImportData))]
+    public static int GetAssemblyImportData(char* buffer, int length)
+    {
+        return Task.Run(() => CorProfiler.Instance.GetAssemblyImportData(buffer, length)).Result;
+    }
 }

--- a/src/Silhouette.IL/CorLibTypes.cs
+++ b/src/Silhouette.IL/CorLibTypes.cs
@@ -121,33 +121,60 @@ internal class CorLibTypes : ICorLibTypes, IDisposable
 
     private AssemblyRef _assemblyRef;
 
-    // TODO: Replace enumeration with IMetaDataAssemblyImport.FindAssemblyRef or similar direct lookup
     private AssemblyRef FindCorLibAssemblyRef()
     {
+        using var assemblyImport = _corProfilerInfo.GetModuleMetaDataAssemblyImport(_moduleId, CorOpenFlags.ofRead)
+            .ThrowIfFailed()
+            .Wrap();
+
         HCORENUM hEnum = default;
-        Span<MdTypeRef> typeRefs = stackalloc MdTypeRef[50];
+        Span<MdAssemblyRef> assemblyRefs = stackalloc MdAssemblyRef[50];
 
         try
         {
-            while (_metadataImport.Value.EnumTypeRefs(ref hEnum, typeRefs, out var count) && count > 0)
+            while (assemblyImport.Value.EnumAssemblyRefs(ref hEnum, assemblyRefs, out var count) && count > 0)
             {
                 for (int i = 0; i < (int)count; i++)
                 {
-                    var (hr, props) = _metadataImport.Value.GetTypeRefProps(typeRefs[i]);
+                    var (hr, props) = assemblyImport.Value.GetAssemblyRefProps(assemblyRefs[i]);
 
-                    if (hr && props.TypeName == "System.Object")
+                    if (!hr)
                     {
-                        return new AssemblyRefUser("corlib") { Rid = MDToken.ToRID((uint)props.ResolutionScope.Value) };
+                        continue;
+                    }
+
+                    if (!IsCorLibName(props.Name))
+                    {
+                        continue;
+                    }
+
+                    // Verify this is the assembly ref the module actually uses for corlib types,
+                    // since modules may reference both System.Runtime and System.Private.CoreLib
+                    // but only use one as the resolution scope for their TypeRefs.
+                    var token = new MdToken(assemblyRefs[i].Value);
+                    var (found, _) = _metadataImport.Value.FindTypeRef(token, "System.Object");
+
+                    if (found)
+                    {
+                        return new AssemblyRefUser(props.Name) { Rid = MDToken.ToRID((uint)assemblyRefs[i].Value) };
                     }
                 }
             }
         }
         finally
         {
-            _metadataImport.Value.CloseEnum(hEnum);
+            assemblyImport.Value.CloseEnum(hEnum);
         }
 
         return null;
+    }
+
+    private static bool IsCorLibName(string name)
+    {
+        return "mscorlib".Equals(name, StringComparison.OrdinalIgnoreCase)
+               || "System.Private.CoreLib".Equals(name, StringComparison.OrdinalIgnoreCase)
+               || "System.Runtime".Equals(name, StringComparison.OrdinalIgnoreCase)
+               || "netstandard".Equals(name, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Silhouette/ICorProfilerInfo.cs
+++ b/src/Silhouette/ICorProfilerInfo.cs
@@ -186,6 +186,12 @@ public class ICorProfilerInfo : Interfaces.IUnknown, ICorProfilerInfoFactory<ICo
         return new(result, new(ptr));
     }
 
+    public HResult<IMetaDataAssemblyImport> GetModuleMetaDataAssemblyImport(ModuleId moduleId, CorOpenFlags dwOpenFlags)
+    {
+        var result = _impl.GetModuleMetaData(moduleId, dwOpenFlags, Interfaces.IMetaDataAssemblyImport.Guid, out var ptr);
+        return new(result, new(ptr));
+    }
+
     public unsafe HResult<ILFunctionBody> GetILFunctionBody(ModuleId moduleId, MdMethodDef methodId)
     {
         var result = _impl.GetILFunctionBody(moduleId, methodId, out var pMethodHeader, out var methodSize);

--- a/src/Silhouette/IMetaDataAssemblyImport.cs
+++ b/src/Silhouette/IMetaDataAssemblyImport.cs
@@ -1,0 +1,261 @@
+using NativeObjects;
+using System.Runtime.CompilerServices;
+
+namespace Silhouette;
+
+public unsafe class IMetaDataAssemblyImport : Interfaces.IUnknown
+{
+    private readonly IMetaDataAssemblyImportInvoker _impl;
+
+    public IMetaDataAssemblyImport(nint ptr)
+    {
+        _impl = new(ptr);
+    }
+
+    public HResult QueryInterface(in Guid guid, out nint ptr)
+    {
+        return _impl.QueryInterface(in guid, out ptr);
+    }
+
+    public int AddRef()
+    {
+        return _impl.AddRef();
+    }
+
+    public int Release()
+    {
+        return _impl.Release();
+    }
+
+    public HResult<AssemblyPropsWithName> GetAssemblyProps(MdAssembly assembly)
+    {
+        ASSEMBLYMETADATA metadata = default;
+        var (result, _) = GetAssemblyProps(assembly, [], out var length, &metadata);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        Span<char> buffer = stackalloc char[(int)length];
+
+        Span<char> localeBuffer = stackalloc char[(int)metadata.cbLocale];
+        metadata.szLocale = (char*)Unsafe.AsPointer(ref localeBuffer.GetPinnableReference());
+
+        (result, var props) = GetAssemblyProps(assembly, buffer, out _, &metadata);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        var locale = metadata.cbLocale > 1 ? new string(localeBuffer[..(int)(metadata.cbLocale - 1)]) : null;
+
+        return new(result, new(
+            buffer.WithoutNullTerminator(),
+            new(metadata.usMajorVersion, metadata.usMinorVersion, metadata.usBuildNumber, metadata.usRevisionNumber),
+            locale,
+            props.PublicKey,
+            props.HashAlgId,
+            props.AssemblyFlags));
+    }
+
+    public HResult<AssemblyProps> GetAssemblyProps(MdAssembly assembly, Span<char> name, out uint nameLength, ASSEMBLYMETADATA* pMetaData)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.GetAssemblyProps(assembly, out var publicKey, out var publicKeyLength, out var hashAlgId, szName, (uint)name.Length, out nameLength, pMetaData, out var assemblyFlags);
+            return new(result, new(new(publicKey, (int)publicKeyLength), hashAlgId, assemblyFlags));
+        }
+    }
+
+    public HResult<AssemblyRefPropsWithName> GetAssemblyRefProps(MdAssemblyRef assemblyRef)
+    {
+        ASSEMBLYMETADATA metadata = default;
+        var (result, _) = GetAssemblyRefProps(assemblyRef, [], out var length, &metadata);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        Span<char> buffer = stackalloc char[(int)length];
+
+        Span<char> localeBuffer = stackalloc char[(int)metadata.cbLocale];
+        metadata.szLocale = (char*)Unsafe.AsPointer(ref localeBuffer.GetPinnableReference());
+
+        (result, var props) = GetAssemblyRefProps(assemblyRef, buffer, out _, &metadata);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        var locale = metadata.cbLocale > 1 ? new string(localeBuffer[..(int)(metadata.cbLocale - 1)]) : null;
+
+        return new(result, new(
+            buffer.WithoutNullTerminator(),
+            new(metadata.usMajorVersion, metadata.usMinorVersion, metadata.usBuildNumber, metadata.usRevisionNumber),
+            locale,
+            props.PublicKeyOrToken,
+            props.HashValue,
+            props.AssemblyRefFlags));
+    }
+
+    public HResult<AssemblyRefProps> GetAssemblyRefProps(MdAssemblyRef assemblyRef, Span<char> name, out uint nameLength, ASSEMBLYMETADATA* pMetaData)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.GetAssemblyRefProps(assemblyRef, out var publicKeyOrToken, out var publicKeyOrTokenLength, szName, (uint)name.Length, out nameLength, pMetaData, out var hashValue, out var hashValueLength, out var assemblyRefFlags);
+            return new(result, new(new(publicKeyOrToken, (int)publicKeyOrTokenLength), new(hashValue, (int)hashValueLength), assemblyRefFlags));
+        }
+    }
+
+    public HResult<FilePropsWithName> GetFileProps(MdFile file)
+    {
+        var (result, _) = GetFileProps(file, [], out var length);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        Span<char> buffer = stackalloc char[(int)length];
+        (result, var props) = GetFileProps(file, buffer, out _);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        return new(result, new(buffer.WithoutNullTerminator(), props.HashValue, props.FileFlags));
+    }
+
+    public HResult<FileProps> GetFileProps(MdFile file, Span<char> name, out uint nameLength)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.GetFileProps(file, szName, (uint)name.Length, out nameLength, out var hashValue, out var hashValueLength, out var fileFlags);
+            return new(result, new(new(hashValue, (int)hashValueLength), fileFlags));
+        }
+    }
+
+    public HResult<ExportedTypePropsWithName> GetExportedTypeProps(MdExportedType exportedType)
+    {
+        var (result, _) = GetExportedTypeProps(exportedType, [], out var length);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        Span<char> buffer = stackalloc char[(int)length];
+        (result, var props) = GetExportedTypeProps(exportedType, buffer, out _);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        return new(result, new(buffer.WithoutNullTerminator(), props.Implementation, props.TypeDef, props.ExportedTypeFlags));
+    }
+
+    public HResult<ExportedTypeProps> GetExportedTypeProps(MdExportedType exportedType, Span<char> name, out uint nameLength)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.GetExportedTypeProps(exportedType, szName, (uint)name.Length, out nameLength, out var implementation, out var typeDef, out var exportedTypeFlags);
+            return new(result, new(implementation, typeDef, exportedTypeFlags));
+        }
+    }
+
+    public HResult<ManifestResourcePropsWithName> GetManifestResourceProps(MdManifestResource manifestResource)
+    {
+        var (result, _) = GetManifestResourceProps(manifestResource, [], out var length);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        Span<char> buffer = stackalloc char[(int)length];
+        (result, var props) = GetManifestResourceProps(manifestResource, buffer, out _);
+
+        if (!result)
+        {
+            return result;
+        }
+
+        return new(result, new(buffer.WithoutNullTerminator(), props.Implementation, props.Offset, props.ResourceFlags));
+    }
+
+    public HResult<ManifestResourceProps> GetManifestResourceProps(MdManifestResource manifestResource, Span<char> name, out uint nameLength)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.GetManifestResourceProps(manifestResource, szName, (uint)name.Length, out nameLength, out var implementation, out var offset, out var resourceFlags);
+            return new(result, new(implementation, offset, resourceFlags));
+        }
+    }
+
+    public HResult EnumAssemblyRefs(ref HCORENUM hEnum, Span<MdAssemblyRef> assemblyRefs, out uint nbAssemblyRefs)
+    {
+        fixed (MdAssemblyRef* rAssemblyRefs = assemblyRefs)
+        {
+            return _impl.EnumAssemblyRefs((HCORENUM*)Unsafe.AsPointer(ref hEnum), rAssemblyRefs, (uint)assemblyRefs.Length, out nbAssemblyRefs);
+        }
+    }
+
+    public HResult EnumFiles(ref HCORENUM hEnum, Span<MdFile> files, out uint nbFiles)
+    {
+        fixed (MdFile* rFiles = files)
+        {
+            return _impl.EnumFiles((HCORENUM*)Unsafe.AsPointer(ref hEnum), rFiles, (uint)files.Length, out nbFiles);
+        }
+    }
+
+    public HResult EnumExportedTypes(ref HCORENUM hEnum, Span<MdExportedType> exportedTypes, out uint nbExportedTypes)
+    {
+        fixed (MdExportedType* rExportedTypes = exportedTypes)
+        {
+            return _impl.EnumExportedTypes((HCORENUM*)Unsafe.AsPointer(ref hEnum), rExportedTypes, (uint)exportedTypes.Length, out nbExportedTypes);
+        }
+    }
+
+    public HResult EnumManifestResources(ref HCORENUM hEnum, Span<MdManifestResource> manifestResources, out uint nbManifestResources)
+    {
+        fixed (MdManifestResource* rManifestResources = manifestResources)
+        {
+            return _impl.EnumManifestResources((HCORENUM*)Unsafe.AsPointer(ref hEnum), rManifestResources, (uint)manifestResources.Length, out nbManifestResources);
+        }
+    }
+
+    public HResult<MdAssembly> GetAssemblyFromScope()
+    {
+        var result = _impl.GetAssemblyFromScope(out var assembly);
+        return new(result, assembly);
+    }
+
+    public HResult<MdExportedType> FindExportedTypeByName(string name, MdToken enclosingType)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.FindExportedTypeByName(szName, enclosingType, out var token);
+            return new(result, token);
+        }
+    }
+
+    public HResult<MdManifestResource> FindManifestResourceByName(string name)
+    {
+        fixed (char* szName = name)
+        {
+            var result = _impl.FindManifestResourceByName(szName, out var token);
+            return new(result, token);
+        }
+    }
+
+    public void CloseEnum(HCORENUM hEnum)
+    {
+        _impl.CloseEnum(hEnum);
+    }
+}

--- a/src/Silhouette/Interfaces/IMetaDataAssemblyImport.cs
+++ b/src/Silhouette/Interfaces/IMetaDataAssemblyImport.cs
@@ -1,0 +1,104 @@
+namespace Silhouette.Interfaces;
+
+[NativeObject]
+public unsafe interface IMetaDataAssemblyImport : IUnknown
+{
+    public static readonly Guid Guid = new("EE62470B-E94B-424e-9B7C-2F00C9249F93");
+
+    HResult GetAssemblyProps(
+        MdAssembly mda,
+        out nint ppbPublicKey,
+        out uint pcbPublicKey,
+        out uint pulHashAlgId,
+        char* szName,
+        uint cchName,
+        out uint pchName,
+        ASSEMBLYMETADATA* pMetaData,
+        out CorAssemblyFlags pdwAssemblyFlags);
+
+    HResult GetAssemblyRefProps(
+        MdAssemblyRef mdar,
+        out nint ppbPublicKeyOrToken,
+        out uint pcbPublicKeyOrToken,
+        char* szName,
+        uint cchName,
+        out uint pchName,
+        ASSEMBLYMETADATA* pMetaData,
+        out nint ppbHashValue,
+        out uint pcbHashValue,
+        out CorAssemblyFlags pdwAssemblyRefFlags);
+
+    HResult GetFileProps(
+        MdFile mdf,
+        char* szName,
+        uint cchName,
+        out uint pchName,
+        out nint ppbHashValue,
+        out uint pcbHashValue,
+        out CorFileFlags pdwFileFlags);
+
+    HResult GetExportedTypeProps(
+        MdExportedType mdct,
+        char* szName,
+        uint cchName,
+        out uint pchName,
+        out MdToken ptkImplementation,
+        out MdTypeDef ptkTypeDef,
+        out CorTypeAttr pdwExportedTypeFlags);
+
+    HResult GetManifestResourceProps(
+        MdManifestResource mdmr,
+        char* szName,
+        uint cchName,
+        out uint pchName,
+        out MdToken ptkImplementation,
+        out uint pdwOffset,
+        out CorManifestResourceFlags pdwResourceFlags);
+
+    HResult EnumAssemblyRefs(
+        HCORENUM* phEnum,
+        MdAssemblyRef* rAssemblyRefs,
+        uint cMax,
+        out uint pcTokens);
+
+    HResult EnumFiles(
+        HCORENUM* phEnum,
+        MdFile* rFiles,
+        uint cMax,
+        out uint pcTokens);
+
+    HResult EnumExportedTypes(
+        HCORENUM* phEnum,
+        MdExportedType* rExportedTypes,
+        uint cMax,
+        out uint pcTokens);
+
+    HResult EnumManifestResources(
+        HCORENUM* phEnum,
+        MdManifestResource* rManifestResources,
+        uint cMax,
+        out uint pcTokens);
+
+    HResult GetAssemblyFromScope(
+        out MdAssembly ptkAssembly);
+
+    HResult FindExportedTypeByName(
+        char* szName,
+        MdToken mdtExportedType,
+        out MdExportedType ptkExportedType);
+
+    HResult FindManifestResourceByName(
+        char* szName,
+        out MdManifestResource ptkManifestResource);
+
+    void CloseEnum(
+        HCORENUM hEnum);
+
+    HResult FindAssembliesByName(
+        char* szAppBase,
+        char* szPrivateBin,
+        char* szAssemblyName,
+        nint* ppIUnk,
+        uint cMax,
+        out uint pcAssemblies);
+}

--- a/src/Silhouette/ProfilerTypes.cs
+++ b/src/Silhouette/ProfilerTypes.cs
@@ -211,6 +211,41 @@ public readonly record struct MdMethodSpec(MdToken Token)
 }
 
 [StructLayout(LayoutKind.Sequential)]
+public readonly record struct MdAssemblyRef(MdToken Token)
+{
+    public int Value => Token.Value;
+    public override string ToString() => Value.ToString("x2");
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct MdAssembly(MdToken Token)
+{
+    public int Value => Token.Value;
+    public override string ToString() => Value.ToString("x2");
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct MdFile(MdToken Token)
+{
+    public int Value => Token.Value;
+    public override string ToString() => Value.ToString("x2");
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct MdExportedType(MdToken Token)
+{
+    public int Value => Token.Value;
+    public override string ToString() => Value.ToString("x2");
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct MdManifestResource(MdToken Token)
+{
+    public int Value => Token.Value;
+    public override string ToString() => Value.ToString("x2");
+}
+
+[StructLayout(LayoutKind.Sequential)]
 public readonly struct MdGenericParamConstraint(MdToken Token)
 {
     public int Value => Token.Value;
@@ -1502,4 +1537,80 @@ public readonly record struct PEKind(CorPEKind Kind, uint Machine);
 public readonly record struct NativePointer<T>(nint Ptr, int Length)
 {
     public unsafe Span<T> AsSpan => new((void*)Ptr, Length);
+}
+
+public readonly record struct AssemblyVersion(ushort Major, ushort Minor, ushort Build, ushort Revision);
+
+public readonly record struct AssemblyProps(NativePointer<byte> PublicKey, uint HashAlgId, CorAssemblyFlags AssemblyFlags);
+public readonly record struct AssemblyPropsWithName(string Name, AssemblyVersion Version, string Locale, NativePointer<byte> PublicKey, uint HashAlgId, CorAssemblyFlags AssemblyFlags);
+
+public readonly record struct AssemblyRefProps(NativePointer<byte> PublicKeyOrToken, NativePointer<byte> HashValue, CorAssemblyFlags AssemblyRefFlags);
+public readonly record struct AssemblyRefPropsWithName(string Name, AssemblyVersion Version, string Locale, NativePointer<byte> PublicKeyOrToken, NativePointer<byte> HashValue, CorAssemblyFlags AssemblyRefFlags);
+
+public readonly record struct FileProps(NativePointer<byte> HashValue, CorFileFlags FileFlags);
+public readonly record struct FilePropsWithName(string Name, NativePointer<byte> HashValue, CorFileFlags FileFlags);
+
+public readonly record struct ExportedTypeProps(MdToken Implementation, MdTypeDef TypeDef, CorTypeAttr ExportedTypeFlags);
+public readonly record struct ExportedTypePropsWithName(string Name, MdToken Implementation, MdTypeDef TypeDef, CorTypeAttr ExportedTypeFlags);
+
+public readonly record struct ManifestResourceProps(MdToken Implementation, uint Offset, CorManifestResourceFlags ResourceFlags);
+public readonly record struct ManifestResourcePropsWithName(string Name, MdToken Implementation, uint Offset, CorManifestResourceFlags ResourceFlags);
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe struct ASSEMBLYMETADATA
+{
+    public ushort usMajorVersion;
+    public ushort usMinorVersion;
+    public ushort usBuildNumber;
+    public ushort usRevisionNumber;
+    public char* szLocale;
+    public uint cbLocale;
+    public uint* rProcessor;
+    public uint ulProcessor;
+    public nint rOS;                    // OSINFO* - deprecated, always null
+    public uint ulOS;
+}
+
+[Flags]
+public enum CorAssemblyFlags : uint
+{
+    afPublicKey                  = 0x0001,  // The assembly ref holds the full (unhashed) public key.
+
+    afPA_None                    = 0x0000,  // Processor Architecture unspecified
+    afPA_MSIL                    = 0x0010,  // Processor Architecture: neutral (PE32)
+    afPA_x86                     = 0x0020,  // Processor Architecture: x86 (PE32)
+    afPA_IA64                    = 0x0030,  // Processor Architecture: Itanium (PE32+)
+    afPA_AMD64                   = 0x0040,  // Processor Architecture: AMD X64 (PE32+)
+    afPA_ARM                     = 0x0050,  // Processor Architecture: ARM (PE32)
+    afPA_ARM64                   = 0x0060,  // Processor Architecture: ARM64 (PE32+)
+    afPA_NoPlatform              = 0x0070,  // Applies to any platform but cannot run on any (e.g. reference assembly), should not have "specified" set
+    afPA_Specified               = 0x0080,  // Propagate PA flags to AssemblyRef record
+    afPA_Mask                    = 0x0070,  // Bits describing the processor architecture
+    afPA_FullMask                = 0x00F0,  // Bits describing the PA incl. Specified
+    afPA_Shift                   = 0x0004,  // NOT A FLAG, shift count in PA flags <--> index conversion
+
+    afEnableJITcompileTracking   = 0x8000,  // From "DebuggableAttribute".
+    afDisableJITcompileOptimizer = 0x4000,  // From "DebuggableAttribute".
+    afDebuggableAttributeMask    = 0xc000,
+
+    afRetargetable               = 0x0100,  // The assembly can be retargeted (at runtime) to an assembly from a different publisher.
+
+    afContentType_Default        = 0x0000,
+    afContentType_WindowsRuntime = 0x0200,
+    afContentType_Mask           = 0x0E00,  // Bits describing ContentType
+}
+
+[Flags]
+public enum CorFileFlags : uint
+{
+    ffContainsMetaData   = 0x0000,  // This is not a resource file
+    ffContainsNoMetaData = 0x0001,  // This is a resource file or other non-metadata-containing file
+}
+
+[Flags]
+public enum CorManifestResourceFlags : uint
+{
+    mrVisibilityMask = 0x0007,
+    mrPublic         = 0x0001,  // The Resource is exported from the Assembly.
+    mrPrivate        = 0x0002,  // The Resource is private to the Assembly.
 }

--- a/src/Silhouette/Silhouette.csproj
+++ b/src/Silhouette/Silhouette.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Silhouette</PackageId>
-    <PackageVersion>4.0.0.0</PackageVersion>
+    <PackageVersion>4.1.0.0</PackageVersion>
     <Title>Silhouette</Title>
     <Authors>Kevin Gosse</Authors>
     <PackageProjectUrl>https://github.com/kevingosse/Silhouette</PackageProjectUrl>

--- a/src/Silhouette/Silhouette.csproj
+++ b/src/Silhouette/Silhouette.csproj
@@ -13,7 +13,7 @@
 
   <PropertyGroup>
     <PackageId>Silhouette</PackageId>
-    <PackageVersion>4.1.0.0</PackageVersion>
+    <PackageVersion>4.0.0.0</PackageVersion>
     <Title>Silhouette</Title>
     <Authors>Kevin Gosse</Authors>
     <PackageProjectUrl>https://github.com/kevingosse/Silhouette</PackageProjectUrl>

--- a/src/TestApp/AssemblyImportTests.cs
+++ b/src/TestApp/AssemblyImportTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+
+namespace TestApp;
+
+internal class AssemblyImportTests : ITest
+{
+    public unsafe void Run()
+    {
+        Logs.Clear();
+
+        var buffer = new char[1024 * 10];
+        int length;
+
+        fixed (char* p = buffer)
+        {
+            length = ProfilerPInvokes.GetAssemblyImportData(p, buffer.Length);
+        }
+
+        Logs.Assert(length >= 0, $"GetAssemblyImportData failed with length={length}");
+
+        var logs = Logs.Fetch().ToList();
+
+        // Verify GetAssemblyFromScope returned a valid token (non-zero)
+        Logs.Assert(logs.Any(l => l.StartsWith("AssemblyImport - GetAssemblyFromScope token=0x") && !l.EndsWith("0x00000000")));
+
+        // Verify GetAssemblyProps returned the correct assembly name
+        Logs.Assert(logs.Any(l => l.StartsWith("AssemblyImport - GetAssemblyProps name=TestApp")));
+
+        // Verify GetAssemblyProps returned version info (version=M.m.B.R pattern)
+        var propsLog = logs.First(l => l.StartsWith("AssemblyImport - GetAssemblyProps"));
+        Logs.Assert(propsLog.Contains("version="), $"GetAssemblyProps missing version: {propsLog}");
+
+        // Verify success
+        Logs.AssertContains(logs, "AssemblyImport - Success");
+
+        // Cross-check assembly refs: names AND versions from profiler vs managed reflection
+        var profilerEntries = ParseNullTerminatedStrings(buffer, length);
+
+        var managedEntries = typeof(AssemblyImportTests).Assembly
+            .GetReferencedAssemblies()
+            .Select(a =>
+            {
+                var v = a.Version ?? new Version(0, 0, 0, 0);
+                return $"{a.Name}|{v.Major}.{v.Minor}.{v.Build}.{v.Revision}";
+            })
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Logs.Assert(
+            profilerEntries.SequenceEqual(managedEntries),
+            $"Assembly ref mismatch.\nProfiler: [{string.Join(", ", profilerEntries)}]\nManaged:  [{string.Join(", ", managedEntries)}]");
+    }
+
+    private static List<string> ParseNullTerminatedStrings(char[] buffer, int length)
+    {
+        var result = new List<string>();
+        var span = new Span<char>(buffer, 0, length);
+
+        while (span.Length > 0)
+        {
+            var nullIndex = span.IndexOf('\0');
+
+            if (nullIndex < 0)
+            {
+                break;
+            }
+
+            result.Add(span[..nullIndex].ToString());
+            span = span[(nullIndex + 1)..];
+        }
+
+        return result;
+    }
+}

--- a/src/TestApp/ProfilerPInvokes.cs
+++ b/src/TestApp/ProfilerPInvokes.cs
@@ -41,4 +41,7 @@ internal static unsafe class ProfilerPInvokes
 
     [DllImport(DllName)]
     public static extern bool TestGetNativeCodeStartAddresses();
+
+    [DllImport(DllName)]
+    public static extern int GetAssemblyImportData(char* buffer, int length);
 }

--- a/src/TestApp/Program.cs
+++ b/src/TestApp/Program.cs
@@ -31,6 +31,7 @@ if (args.Length >= 2 && args[0] == "--attach")
     attachTests.Add(new GenericArgumentsTests());
     attachTests.Add(new IlRewriteTest());
     attachTests.Add(new CorLibTypesTest());
+    attachTests.Add(new AssemblyImportTests());
     attachTests.Add(new FunctionInfoTests());
 
     return RunTests(attachTests);
@@ -74,6 +75,7 @@ var tests = new List<ITest>
     new GenericArgumentsTests(),
     new IlRewriteTest(),
     new CorLibTypesTest(),
+    new AssemblyImportTests(),
     new FunctionInfoTests()
 };
 


### PR DESCRIPTION
- Add `IMetaDataAssemblyImport` COM interface wrapper with correct vtable order (per [cor.h](https://github.com/dotnet/runtime/blob/cac7b4dd9fa2a27fa1f02767e5f0b100e6221b2e/src/coreclr/inc/cor.h#L1215))
- Add specialized token types: `MdAssemblyRef`, `MdAssembly`, `MdFile`, `MdExportedType`, `MdManifestResource`
- Add `ASSEMBLYMETADATA` struct, `CorAssemblyFlags`, `CorFileFlags`, `CorManifestResourceFlags` enums with comments from corhdr.h
- Add `GetModuleMetaDataAssemblyImport` convenience method to `ICorProfilerInfo`
- Replace TypeRef enumeration in `CorLibTypes.FindCorLibAssemblyRef` with `IMetaDataAssemblyImport.EnumAssemblyRefs`/`GetAssemblyRefProps`
- High-level wrapper exposes managed-friendly APIs for: `GetAssemblyProps`, `GetAssemblyRefProps` (with version/locale from `ASSEMBLYMETADATA`), `GetFileProps`, `GetExportedTypeProps`, `GetManifestResourceProps`, `EnumAssemblyRefs`, `EnumFiles`, `EnumExportedTypes`, `EnumManifestResources`, `GetAssemblyFromScope`, `FindExportedTypeByName`, `FindManifestResourceByName`
- `FindAssembliesByName` kept in interface (vtable correctness) but not wrapped — returns `0x80131515` from profiler context
